### PR TITLE
Documentation revision

### DIFF
--- a/documentation/docs/build_system/c2module.md
+++ b/documentation/docs/build_system/c2module.md
@@ -18,8 +18,11 @@ public func int32 main(int32 argc, char*[] argv) {
 No need for dirty macros, code-generation scripts etc...
 
 In addition, the C2 module also holds some commonly used symbols. This way, no symbols
-have to be placed at the global namespace and thus naming conflict can always be
-resolved by a programmer.
+have to be placed at the global namespace and thus a naming conflict can always be
+resolved by the programmer.
 
 See [Basic types](../language/basic_types.md) for a list of symbols.
+
+The C2 also contains several C types used to map C functions to C2's interface files.
+See [External Libraries](libraries/) for information on the types and interface files.
 

--- a/documentation/docs/build_system/diagnostics.md
+++ b/documentation/docs/build_system/diagnostics.md
@@ -1,10 +1,10 @@
 
-One of the perks of telling the compiler everything, is that it can do much more
+One of the perks of telling the compiler everything is that it can do much more
 for you. This page describes some of the special ones.
 
 ## Unused warnings
-Most diagnostic messages will be errors, but of the warnings, unused are the most
-common.
+Most diagnostic messages will be errors, but out of the warnings, warnings for unused
+symbols are the most common.
 
 ### unused variables
 
@@ -19,7 +19,7 @@ public func void foo() {
 ```
 
 ### functions
-All functions of the entire program can be checked for used.
+All functions of the entire program can be checked for usage.
 
 ```c
 module test;

--- a/documentation/docs/build_system/intro.md
+++ b/documentation/docs/build_system/intro.md
@@ -1,10 +1,10 @@
 
 The scope of C2 language is larger than just the code itself; it also includes the
 build system. Including this allows doing many nice things easily, like LTO (link
-time optimization, etc).
+time optimization), etc.
 
 ## recipe
-A C2 project has a `recipe` file. This file describes:
+A C2 project requires a `recipe` file. This file describes:
 
 * the target type (executable, shared library or static library)
 * which options are used (compile time flags)
@@ -18,7 +18,7 @@ The exact format of the recipe file is still in progress, but it currently looks
 ```ini
 # an example recipe file
 
-target hello
+executable hello
   $warnings no-unused
   sources/hello.c2
 end
@@ -34,12 +34,12 @@ Note that the path to each c2 file is relative to the position of the __recipe f
 to that of the c2c binary.
 
 ### calling directory
-When building these targets, `c2c` is only called __once__. This way the compiler knows the
-target type and all files required. Since you might be working in some subdir of your
-project, c2c will iteratively search dirs to root until *recipe.txt* is found, no
+When building targets, `c2c` is only called __once__. This way the compiler knows the
+target type and all required files. Since you might be working in some subdir of your
+project, c2c will iteratively search dirs to root until *recipe.txt* is found - no
 need to change dirs to run it!
 
-So these 2 calls are equal if *my_project/* contains the *recipe.txt*:
+So these two calls are equal if *my_project/* contains the *recipe.txt*:
 ```
 ~my_project$ c2c
 ~my_project/some_subdir$ c2c
@@ -47,18 +47,18 @@ So these 2 calls are equal if *my_project/* contains the *recipe.txt*:
 
 
 ### output directory
-Any output will be put in the *output/* directory in the root of the project. Inside
- the output directory, each target will have its own folder.
+Any output will be placed in the *output/* directory generated in the root directory of the project.
+Inside the output directory, generated files of each target will have their own folder.
 Therefore, to *make clean* just means to remove this directory.
 
 ## Options
 
 Inside a target, the following options are available:
 
- * *config [names]* - specify definitions, like #define feature1
- * *export [modules]* - exports the modules in libraries and generated headers
- * *generate-c* - enables generation of C code
- * *generate-ir* - enables generation of LLVM IR code
+ * *config [names]* - specify definitions for the preprocessor, like #define feature1
+ * *export [modules]* - export the modules in libraries and generated headers
+ * *generate-c* - enable generation of C code
+ * *generate-ir* - enable generation of LLVM IR code
  * *warnings [list]* - enable/disable specific warnings during compilation
  * *deps [options]* - enable generation of dependency file with certain options
  * *refs* - generate reference file (used for jumping to definition)

--- a/documentation/docs/build_system/libraries.md
+++ b/documentation/docs/build_system/libraries.md
@@ -1,14 +1,14 @@
 
-C2 is an *evolution* of C. So one design criteria would be easy integration with
+C2 is an *evolution* of C. So one design criterion would be easy integration with
 existing C libraries. This section explains how C2 integrates external C libraries.
 
 ## C/C++ library support
-Let's start this section by first looking at existing library support in C (orC++).
+Let's start this section by first looking at existing library support in C (or C++).
 The first thing to realize is:
 
 __C does not have true library support!__
 
-This may sound weird, considering that there a thousands of C libraries out there.
+This may sound weird considering that there thousands of C libraries out there.
 But the C-*language* doesn't know the concept of libraries. Using libraries in C consists
 of several *separate* steps:
 
@@ -17,22 +17,22 @@ of several *separate* steps:
 * passing some extra flags to the linker to tell it to include a dependency or extra
 object files.
 
-Both steps also have some supporting features like setting search-paths for headers/libraries etc
+Both steps also have some supporting features like setting search paths for headers/libraries etc.
 You can forget either of the steps. For example, forgetting the second step will usually result in some
 cryptic *undefined reference to X* errors during linking. So it's up to the programmer to
 do both steps.
 
 ## C2 library design
-In C2, the compiler does have a concept of a library. So using a library is more an
-atomic action; either you use it or not. Also every used library needs to be specified
-in the recipe file. There is one exception to this rule: use of *libc* is opt-out. So by
-default a program can use it. This is a convenience choice.
+In C2, the compiler does have a concept of a library. So using a library is more of an
+atomic action; either you use it or not. Also every library in use needs to be specified
+in the recipe file. There is one exception to this rule: usage of *libc* is opt-out. By
+default each program uses it. This is a convenience choice.
 
 c2c uses an environment variable called *$C2_LIBDIR* indicating the directory where
 libraries can be found. In this directory, each library as its own subdirectory, as
 shown below.
 
-NOTE: in the near future, extra paths can be given in the recipe file.
+NOTE: In the near future, extra paths can be given in the recipe file.
 
 ```bash
 c2libs/
@@ -44,12 +44,12 @@ c2libs/
     └── strings.c2i
 ```
 
-To be valid, a library-directory has to contain a *manifest* file and one or
+To be valid, a library directory has to contain a *manifest* file and one or
 more *interface* files.
 
 ###manifest file
-Since C2 doesn't use *#include* headers, a mechanism is needed to map C header files
-to C2 modules. This mechanism is the *manifest* file.
+Since C2 doesn't use *#include* headers, a new mechanism is required to map C header
+files to C2 modules. This is the purpose of a *manifest* file.
 
 ```toml
 # C2 wrapper for the standard C library
@@ -77,8 +77,8 @@ there can be two options: C or C2. Using C indicates that symbol-generation shou
 prefix the declaration name with the module name. For example: *printf* simply becomes
 the symbol *printf*, not *stdio_printf*.
 
-The rest of the file maps specific C headers files to C2 modules. Optionally, the *header*
-line describes which c-header should be included by the C-generation back-end.
+The rest of the file maps specific C header files to C2 modules. Optionally, the *header*
+line describes which C header should be included by the C generation back-end.
 
 It's also possible to specify dependencies of a library in the manifest file:
 
@@ -107,12 +107,12 @@ While C2 does not have header files or an *#include* mechanism, it does have *in
 files. These are similar to regular .c2 files, except for:
 
 * they have the .c2i extension (c2 interface, get it?)
-* functions can have no body
+* functions can not have a body
 * every declaration is public by default
-* the filename (except .c2i) must match the module name inside (eg foo.c2i -> module foo; )
+* the filename (without the ".c2i" extension) must match the module name inside ( eg.: foo.c2i -> module foo; )
 * there can be only one file per module
 
-Part of *stdio.c2i* looks like this:
+For example, a fraction of *stdio.c2i* looks like this:
 
 ```c2
 module stdio;
@@ -131,7 +131,7 @@ func c_int sprintf(c_char* __s, const c_char* __format, ...);
 
 // .. (stuff left out)
 ```
-C2 has special types for creating interface files of C libraries. These are in the C2 module:
+C2 has special types for creation of interface files for C libraries. These are defined in the C2 module:
 
 * c_char
 * c_int
@@ -154,7 +154,7 @@ will mean generating a *manifest* and *.c2i files*.
 
 To make the situation a bit more complex, C2C also has a C-backend. So internally
 it can generate .c/.h files to build targets. These header files should not be
-confused with the interface headerfiles described above. To explain, see the image
+confused with the interface header files described above. To explain, see the image
 below.
 ![build flow](build_libs.svg)
 A lot of things are happening here, so please take some time to study the image.
@@ -195,10 +195,10 @@ So the user of a lib must specify whether to use the dynamic/static version.
 
 ###building C-application
 The same library can also be used by C programs, by simply including the *mylib.h*
-and *mylib_extra.h* in *application.c*. This is no different then using any other
-c-library.
+and *mylib_extra.h* in *application.c*. This is no different than using any other
+C library.
 
-##advantages of integrated library-support
+##advantages of integrated library support
 
 There are several additional advantages of integrating library support in the language
 
@@ -215,7 +215,7 @@ The compiler can generate a full dependency map of all symbols, including extern
 ones. This allows better insight into the code structure.
 
 ###c2tags
-*c2tags* is the tool that allows editors to 'jump to definition' of any symbol. Because
+*c2tags* is a tool that allows editors to 'jump to definition' of any symbol. Because
 of the interface files, that describe external symbols, editors have a place to jump
 to for all symbols. This is a very powerful feature. Never mess with ctags files
 ever again.

--- a/documentation/docs/build_system/symbols.md
+++ b/documentation/docs/build_system/symbols.md
@@ -1,4 +1,4 @@
 
-For libraries, all __public__ symbols of __exported__ modules are visible in the
+For libraries, all __public__ symbols of the __exported__ modules are visible in the
 resulting binary. This gives developers easy control over `symbol visibility`.
 

--- a/documentation/docs/development/automated_tests.md
+++ b/documentation/docs/development/automated_tests.md
@@ -1,11 +1,11 @@
 
-The c2c sources include a *test/* directory will automated tests. To tool to run
-these in located in <c2compiler/tools/tester>. These tests are modelled after
-clang's unit test framework and are designed to create tests with minimal effort.
+The c2c sources include a *test/* directory with automated tests. The tool to run
+these is located in <c2compiler/tools/tester>. These tests are modelled after
+clang's unit test framework and are designed allow creating tests with minimal effort.
 
-There are several types of tests:
+There are several types of test for testing:
 
-* test generated diagnostic notes, warnings and errors
-* test generated C code
-* test generated IR code
+* generated diagnostic notes, warnings and errors
+* generated C code
+* generated IR code
 

--- a/documentation/docs/development/contributing.md
+++ b/documentation/docs/development/contributing.md
@@ -3,14 +3,14 @@
 * discussion on the forum ([found here](http://c2lang.org/forum) )
 * submitting patches or pull requests
 * writing documentation
-* use __c2c__ and give feedback
+* using __c2c__ and providing feedback
 
 ### logo
 We also have an outstanding request for a logo. So if you're creative with graphics,
-you can be the designer of the logo of a next-gen language..
+you can be the designer of the logo for a next-gen language..
 
 ### forum
-We had to disable the automated forum registration, since the forums
+We had to disable the automated forum registration since the forums
 were constantly being spammed. See the __Joining__ category in the forum on
 how to manually register.
 

--- a/documentation/docs/development/current_status.md
+++ b/documentation/docs/development/current_status.md
@@ -9,6 +9,6 @@ Analyser | 60% | needs improved *type checking*, *un-initialized* diagonostics
 C generator | 95% | some corner cases still need to be implemented
 IR generator | 5% | basically only *Hello World* works (functions, strings, function calls)
 
-So the short status would be that for playing around with the language using the C-generation
+So the short status would be that for playing around with the language using the C-generating
 back-end, it's pretty usable.
 

--- a/documentation/docs/development/internals.md
+++ b/documentation/docs/development/internals.md
@@ -6,30 +6,30 @@ This section describes how the C2 compiler (c2c) is structured.
 
 Each component will be described in detail below. The colors mean:
 
-- green: used un-modified
-- light blue: not-used
+- green: used unmodified
+- light blue: not used
 - blue: new components
 - orange: modified from the original
 
 ### LLVM
-The [LLVM Project](http://llvm.org) provides great building block for
+The [LLVM Project](http://llvm.org) provides great building blocks for
 compilers. Just what we need!
 
 __IR__ (Intermediate Representation) is roughly an assembly-like language
 and is used as input for LLVM. On the IR code, various optimizations can be
-applied and code can be generated for various targets (like ARM, PowerPC, X86, etc)
-Additionally the LLVM code holds many util-like functionality.
+applied and code can be generated for various targets (like ARM, PowerPC, X86, etc.).
+Additionally the LLVM code holds much utility functionality.
 
-For C2 we use LLVM unmodified!
+For C2 we use the LLVM unmodified!
 
 ### Clang
 [Clang](http://clang.llvm.org) is a C/C++/Objective-C compiler that uses
-LLVM as back-end. Very briefly, it works like this.
+LLVM as its back-end. Very briefly, it works like this:
 
 Clang has a __Lexer__ that provides symbols to the __Parser__. The Parser then calls
 the  __Sema__ (Semantic Analyser) to do analysis and build up the __AST__ (abstract syntax tree).
 The __CodeGen__ components take the __AST__ and convert it into __IR__ code for LLVM.
-To support this, there are various Util libraries and a __Diagostics__ component to
+For this, there are various Util libraries and a __Diagostics__ component to
 display beautiful error messages.
 
 Both LLVM and Clang are compiled into roughly 50 static libraries that can
@@ -40,9 +40,9 @@ __designer's note__:
 
 C2C does not use Clang's AST and Parser/Sema. This would have provided a *lot* of
 functionality out of the box. However, since C2 does not have forward declarations
-and does not require any ordering on file level, it requires multi-pass analysis.
-This does not fit at all into Clang's intra-structure that is based on C-like
-langugages, where there can be single pass compilation.
+and does not require any ordering on file level, a multi-pass analysis is required.
+This does not fit into Clang's infrastructure all, since it is based on C-like
+languages, where can be just a single pass compilation.
 
 
 ### C2 Compiler

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -17,41 +17,41 @@ This philosophy leads to the following design goals:
 * great tooling (formatting tool, graphical refactoring tool)
 * easy integration with C libraries
 * should be easy to learn for C programmers
-* should support avoiding common mistakes
+* should help to avoid common mistakes
 
 As such, since C2 is an __evolution__ of C, it has explicit __non goals__:
 
-* higher-level features (like object-orientation, garbage collection, etc)
-* completely new language
+* higher-level features (like object-orientation, garbage collection, etc.)
+* to be a completely new language
 
 ### advantages
 So *Why* would you choose C2 over C?
 
 * __faster__ development. Our tests show around __30%__ decrease in development time!!
 * easy access to features like LTO (link-time optimization)
-* better diagnostics (again speeds up development)
+* better diagnostics (which, again, speeds up development)
 * easier control over *architecture* with __c2reto__
 
 
 ### domain
-new programming languages appear quite frequently nowadays. For example
+New programming languages appear quite frequently nowadays. For example
 __D__, __Rust__, __Go__, __Swift__, just to name a few of the big names.
 Each of these try to solve problems in a specific *domain*. For example,
 both __D__ and __Rust__ aim to be *system-level* programming languages,
 so a valid alternative to C++.
 
 *C2 aims to be used for problems where currently C would be used*. So low-level
-programs, like bootloaders, kernels, drivers and system-level tooling.
+programs like bootloaders, kernels, drivers and system-level tooling.
 
 ### programming language evolution
 
 ![languages](introduction/languages.svg)
 
-In programming language development, there has been a trend towards higher-level,
-more abstraction. Java and C# especially reflect this trend. For system-level
-languages, D and Rust have reverted some of this trend, to give better performance and
+In the programming language development, there has been a trend towards more, higher-level,
+abstractions. Java and C# especially reflect this trend. For system-level
+languages, D and Rust have strayed away from this trend, to provide better performance and
 control. For a system-level language, the features offered by C++, D and Rust are
 very suitable. However, they do not seem to fill the gap for low-level/embedded
-programs, since these are often still programmed in C. This gap is exactly one
-that C2 attempts to fill.
+programs, since these are often still programmed in C. This gap is exactly the one
+C2 attempts to fill.
 

--- a/documentation/docs/introduction/changes_from_c.md
+++ b/documentation/docs/introduction/changes_from_c.md
@@ -1,5 +1,5 @@
 
-Because C2 is an _evolution_ of C, this page summarizes the
+Since C2 is an _evolution_ of C, this page is here to summarize the
 _changes_ made and the design philosophy behind it.
 
 *TODO this page is in progress*
@@ -8,18 +8,18 @@ _changes_ made and the design philosophy behind it.
 ### Language changes
 
 * no Header files
-    consequence: import statement, and modules
+    consequence: import statement and modules
 
 * no forward declarations
     philosophy: types the same thing twice, reduces development speed
-    consequence: needs multi-pass compiler
+    consequence: requires a multi-pass compiler
 
 * member access always through '.', not sometimes '->'
     philosophy: remove clutter/reduce change effort
 
 * Unified type definitions
 
-* All globals variables are initialized by default
+* All global variables are initialized by default
 
 * [Standardized attribute syntax](../language/attributes)
 
@@ -39,6 +39,6 @@ C2 also introduces some *NEW* features:
 
 * [Incremental arrays](../language/variables/#incremental-arrays)
 
-* More tooling integration, like dependency and refs file generation
+* More tooling integration like dependency and refs file generation
 
 

--- a/documentation/docs/introduction/code_fragments.md
+++ b/documentation/docs/introduction/code_fragments.md
@@ -1,7 +1,7 @@
 
-This section just shows some code fragments to give you a feel for the language.
-As you'll see, must code *inside* function bodies is almost identical to C, but
-code *outside* differs just a bit.
+This section just shows some code fragments to give you a feel of the language.
+As you'll see, most code *inside* function bodies is almost identical to C, but
+code *outside* differs a bit.
 
 ### if-statement
 ```c
@@ -78,7 +78,7 @@ func void demo_enum(Height h) {
 ```
 
 To prevent having to add artificial enum constants to determine the range of an enum (for int to enum
-conversion etc), C2 adds two keywords _enum_min_ and _enum_max_.
+conversion etc.), C2 adds two keywords - _enum_min_ and _enum_max_.
 
 ```c
 type State enum uint32 {

--- a/documentation/docs/introduction/evolution.md
+++ b/documentation/docs/introduction/evolution.md
@@ -1,7 +1,7 @@
 
 __NOTE:
-while might be seen as critique on C, they are not. C is an
-awesome language that survived the test of time for more than 40 years!
+While this might be seen as critique of C, it is not. C is an
+awesome language that has survived the test of time for more than 40 years!
 Respect to its designer...__
 
 *"Evolution consists of mutation and selection.."*
@@ -12,39 +12,43 @@ Things that are seen as *bad* nowadays and can be improved:
 
 - header-file includes.
 - complex/un-readable type syntax
- (can you read ```char *(*(**foo [][8])())[];```?)
+  (can you read ```char *(*(**foo [][8])())[];```? see the bottom of the page for the correct answer)
 - very hard for tooling
-- needs external build system
+- needs an external build system
 
-C was designed in an era when the compiler had to do with very limited processing
-power and memory. Nowadays these restrictions simply don't apply anymore and it would
-be better to put more work on the compiler instead of on the developer.
+C was designed in an era when the compiler had to work with very limited processing
+power and memory. Nowadays, these restrictions simply don't apply anymore and it would
+be better to put more work into the compiler instead of onto the developer.
 
-One of the major show-stoppers in C is the use of header-file includes. The clang
+One of the major show-stoppers in C is the use of header file includes. The clang
 website has a [very nice article](http://clang.llvm.org/docs/Modules.html#problems-with-the-current-model) on
 the problems of #include.
 Because #includes are recursive, the compiler often has to parse and analyse a lot more
 then just your code. Tests on regular C code have shown the factor of user code / external code
-to be roughly 50 times. So for every line you provide, the compiler needs to parse and
+to be roughly 1 to 50. So for every line of code you write, the compiler needs to parse and
 analyse 50 lines!
 
-Additionally, the frequent use of preprocessor macros gives headaches to tool developers
+Additionally, frequent use of preprocessor macros gives headaches to tool developers
 and code analysers.
 
 ## overview of changes
 This section describes the main differences between C and C2.
 
 ### no header files
-C2 uses a modern approach to using external symbols. There is only one type
-of file, .c2 source files. To replace the ```#include```, there is an __import__
-statement. Also all sources are put into [Modules](../language/modules.md).
+C2 uses a modern approach for usage of external symbols. There is only one type
+of files, the **.c2** source files. To replace the ```#include```, there is an __import__
+statement. Also all source code is divided into [Modules](../language/modules.md). Having modules
+as compilation units rather than plain files allows extra flexibility, especially since a module
+can span over several files, which can be taken in and out at will if needed.
 
-__no ordering__
+__no mandatory declaration ordering__
 
-Also there are no *forward declarations* of any kind. Each declaration is just
-defined in a single place. This implies no ordering requirements within a source
-file. So top level declarations can be written in any order. The example below
-is valid
+There are no *forward declarations* in C2 of any kind. Each declaration is just
+defined in a single place. This implies that there are no ordering requirements
+of any kind within a source file. That means that top level declarations can be
+written in any order, which allows the programmer to sort their declaration in a
+way that suites them and their needs the most rather than the way the compiler
+dictates as it is with C. The example below is valid:
 
 ```c
 // type Number and global variable n are used here
@@ -58,7 +62,7 @@ type Number int32;
 ```
 
 ### integrated build system
-Integrating the build system into the compiler may seem restrictive, but actually
+Integrating the build system into the compiler may seem restrictive, but it actually
 enables a lot of improvements. See [this page](../build_system/intro.md) for a
 description of the build system.
 
@@ -68,24 +72,24 @@ The image below show the difference between traditional C compilation and C2 com
 
 In C, the compiler is called separately for each .c file and asked to parse and
 analyse it, then generate the object code. Afterwards, all object files are linked
-into an executable or library.
+into an executable or a library.
 
-In C2, all files are first parsed, then all files are analysed in successive passes.
-Only if there are no errors, is code generation started.
+In C2, all files are first parsed, then analysed in successive passes.
+Only when there are no errors is the code generation started.
 
 The code generation (and optimization) steps require a lot of time. So if you have
 100 C source files and the 99th file has a syntax error, the compiler has to go through
-a lot of work before showing the diagnostic. In C2 it would only take very little time.
+a lot of work before showing the diagnostic. In C2 it only takes very little time.
 So during development, developers never have to wait for diagnostic messages.
 
 ### compilation per target, not file
-One feature the integrated build system offers, is an easy way for developers to
+One feature the integrated build system offers is an easy way for developers to
 have control over how their code is built. Traditionally, C programs are compiled
 as follows:
 ![ansic](build_ansic.svg)
-So each source file in turned into an LLVM module (IR code). The LLVM module is the
-scope for the optimization pass. Then object code is generated (.o file). So the
-optimizer passes only get a single piece of the puzzle each time.
+So each source file is turned into an LLVM module (IR code). The LLVM module is the
+scope for the optimization pass. Then object code is generated (the **.o** file), which means
+the optimizer passes only get a single piece of the puzzle each time.
 
 In C2 the developer can choose between 2 modes: single module or multiple modules.
 In multi-modules mode (the default), all source files within the same C2 module are
@@ -99,11 +103,11 @@ optimization' in C is very hard for any realistic size project. In C2 it can be 
 enabled in the recipe file.
 ![single](build_single.svg)
 
-Also the *visibility* of symbols in the resulting binary can be easily controlled
+Also the *visibility* of the symbols in the resulting binary can be easily controlled
 without the use of linker scripts or special tools as described in the
 [Export control section](../build_system/symbols.md).
 
-For more information about targeting and the build system, 
+For more information on targeting and the build system,
 please visit [Build system section](../build_system/symbols.md).
 
 ### built-in primitive types
@@ -115,36 +119,36 @@ C2 provides the following built-in primitive types:
 * __float32__, __float64__
 * __char__ (equal to int8)
 
-The default __int__ and __float__ types have been removed, as have type modifier like
-__short__, __long__, __signed__, __unsigned__.
+The default __int__ and __float__ types have been removed along with type modifiers such as
+__short__, __long__, __signed__, or __unsigned__.
 
 The `NULL` macro, has been replaced by the __nil__ keyword.
 
 ### uniform type (definition) syntax
 Type definitions in C are sometimes hard to read. Also the syntax is a bit weird with
-the typedef's. C2 provides a uniform syntax to define new types, as shown
+the typedef's. C2 provides uniform syntax to define new types, as shown
 [here](../language/user_types.md).
 
 ### stricter diagnostics
-Most project in C lose quite some time tweaking the warning levels. To get optimal
-diagnostics from a C compilers requires passing a lot of options.
+A lot of projects in C lose quite some time tweaking the warning levels. Getting optimal
+diagnostics from a C compiler requires passing it a lot of options.
 
 The C2 language only uses a few warnings (mostly about unused import/type/var/function/etc).
-All other diagnostics are simply an error.
+All the other diagnostics are simply an error.
 Examples of errors in C2:
 
-* using uninitialized variable
+* using an uninitialized variable
 * not returning anything from non-void function
 * some type conversions
 
 Thanks to the stricter diagnostics, c2c tells you where exactly the error is located,
 what kind of error is it, as well as showing a possible fix in some cases, for example for
-a missing semicolon after a function call. Again, this speeds up develepment time, because
+a missing semicolon after a function call. Again, this speeds up development time, because
 you don't need to frantically search for the root of your problem for as much time as in C.
 
 ### attributes
 The C2 language design includes [attributes](../language/attributes.md). Out of the box,
-C2 supports standardized attributes. Compiler-specific once are also still possible. This simplifies
+C2 supports standardized attributes. Compiler-specific ones are also still available. This simplifies
 the development of multi-platform code.
 
 ### tooling
@@ -157,3 +161,7 @@ C2 also introduces some new features:
 * [incremental arrays](../language/variables.md#incremental-arrays)
 * [c2 pseudo-module](../build_system/c2module.md)
 
+
+
+#### correct answer for the type declaration above
+foo is an array of arrays of 8 pointers to pointers to a function returning a pointer to an array of char pointers.

--- a/documentation/docs/introduction/helloworld.md
+++ b/documentation/docs/introduction/helloworld.md
@@ -1,5 +1,5 @@
 
-Enough philosophy, let's talk code, let's talk Hello world...
+Enough philosophy, let's talk code, let's talk Hello world!
 
 `hello.c2`
 ```c
@@ -13,7 +13,7 @@ func int32 main(int32 argc, char*[] argv) {
 }
 ```
 
-Spot the __six__ differences.. (with C)
+Spot the __six__ differences from C:
 Scroll down for the answer
 
 .
@@ -32,7 +32,7 @@ Scroll down for the answer
 
 .
 
-Here they are:
+Here it is:
 
 1. __module__ keyword, see [modules](../language/modules.md)
 2. __import__ replaced #include, see [Import](../language/modules.md#import)

--- a/documentation/docs/language/attributes.md
+++ b/documentation/docs/language/attributes.md
@@ -1,9 +1,9 @@
 ## Attributes
 
-C2 incorporates standardized __attributes__. There can also be compiled-specific attributes
-to do all sort of funky things compilers do.
+C2 incorporates standardized __attributes__. There can also be compiler-specific attributes
+to do all sorts of funky things the compilers do.
 
-Currently supported attributes are:
+The currently supported attributes are:
 
 * __export__ (type, func, var)
 * __packed__ (type)
@@ -52,7 +52,7 @@ The __opaque__ attribute deserves some special attention. It is used to implemen
 the *opaque pointer* pattern in C2. See the Wikipedia article
 [Opaque Pointer](https://en.wikipedia.org/wiki/Opaque_pointer) for more background info.
 
-In short, Opaque pointers are used to hide the implementation while giving the users
+In short, opaque pointers are used to hide the implementation while giving the users
 a *typed handle* to
 pass to your library, maintaining type safety. The __opaque__ attribute can only
 be used on *public struct/union types* and tells the compiler that *other*
@@ -69,7 +69,7 @@ when c2c generates an *interface file* (eg. module.c2i), it will only generate
 type Handle struct {} @(opaque)
 ```
 
-Note that it is allowed to put other non-public types as full member inside
-a public, opaque struct, since the members are not visible outside the module.
+Note that it is allowed to put other non-public types as full members inside
+a public opaque struct, since the members are not visible outside the module.
 
 

--- a/documentation/docs/language/basic_types.md
+++ b/documentation/docs/language/basic_types.md
@@ -1,9 +1,9 @@
 
 ## primitive types
 
-C2 has the following builtin primitive types:
+C2 has the following built-in primitive types:
 
-* __bool__. can be __true__ or __false__
+* __bool__. can be either __true__ or __false__
 * __int8__, __int16__, __int32__, __int64__. The signed types
 * __uint8__, __uint16__, __uint32__, __uint64__. The unsigned types
 * __float32__, __float64__. Floating point types
@@ -15,7 +15,7 @@ Note that C2 does __not__ have any type specifiers like __signed__, __unsigned__
 
 ### c2 pseudo-module ###
 The c2compiler always has a pseudo module called __c2__. This module is used to
-store some language symbols like min/max values and things like build-time, etc.
+store some language symbols such as min/max values and things like build time, etc.
 For each integer type there exists a min/max value:
 
 * __min_int8__, __max_int8__
@@ -33,6 +33,9 @@ import c2;
 
 int32 highest = c2.max_int32;
 ```
+
+It also includes some C type for mapping C declarations in libraries to C2 interface types.
+See [External Libraries](../build_system/libraries/) for more information.
 
 ## pointer types
 

--- a/documentation/docs/language/basics.md
+++ b/documentation/docs/language/basics.md
@@ -1,7 +1,7 @@
 
 ## comments
 
-C2 allows comments in the same way as C. Thus 2 forms are available:
+C2 comments work in the same way as C's. Thus both forms are available:
 
 ```c
 // a one line comment
@@ -13,7 +13,7 @@ C2 allows comments in the same way as C. Thus 2 forms are available:
 
 ## semi-colons
 
-Every statement in C2 is followed by a semi-colon, __except__ when it ends with
+Every statement in C2 is followed by a semicolon, __except__ when it ends with
 a __right-hand brace__: } !!
 Trailing attributes never change the rule above.
 

--- a/documentation/docs/language/bitoffsets.md
+++ b/documentation/docs/language/bitoffsets.md
@@ -1,10 +1,10 @@
 
 A new feature in C2 are __bit-offsets__.
 
-NOTE: dont confuse __bit-offsets__ with __bit-fields__, which are x-bit wide fields inside a
-struct member.
+NOTE: Dont confuse __bit-offsets__ with __bit-fields__, which are x-bits wide fields inside a
+struct for memory conservation.
 
-Bit-offsets are used in code that often needs to fetch certain bits from registers, like
+Bit-offsets are used in code that often needs to fetch certain bits from registers, such as
 driver code.
 
 The syntax of a bit-offset is `value[<highest bit>:<lowest bit>]`.

--- a/documentation/docs/language/functions.md
+++ b/documentation/docs/language/functions.md
@@ -2,7 +2,7 @@
 
 Functions start with the __func__ keyword; otherwise they look very similar to
 C. Since there are no forward declarations of any kind in C2, there is just one
-form, namely the function definition itself.
+form, which is the function definition itself:
 
 ```c
 public func int32 main(int32 argc, char*[] argv) {
@@ -10,4 +10,4 @@ public func int32 main(int32 argc, char*[] argv) {
 }
 ```
 
-For function attributes, see [attributes](attributes.md).
+Functions can also have attributes. More information on attributes can be found [here](attributes.md).

--- a/documentation/docs/language/keywords.md
+++ b/documentation/docs/language/keywords.md
@@ -3,7 +3,7 @@
 
 C2 has the following keywords:
 
-### Generic
+### Module related
 * module
 * import
 * as

--- a/documentation/docs/language/modules.md
+++ b/documentation/docs/language/modules.md
@@ -1,9 +1,9 @@
 ## modules
 
-Like many other modern languages, C2 has the concept of `modules`. Modules are
+Like many other modern languages, C2 uses the concept of `modules`. Modules are
 used to create logical groups of functions, types and variables. Each __.c2__
 file has to start with the __module__ keyword, specifying which module it belongs
-to. A module can consist of several files, such as:
+to. A module can consist of several files, for example:
 
 `file1.c2`
 ```c
@@ -27,13 +27,13 @@ module bar;
 ```
 
 file1.c2 and file2.c2 belong to the same module, `foo`, while file3.c2 belongs to
-module `bar`.
+the module `bar`.
 
-Modules allow a developer to split functionality into several files, *without*
-sacrificing speed or adding complexity.
+Modules allow the developer to split functionality into several files, *without*
+sacrificing speed or introducing extra complexity.
 
 ## import
-To have a file use declarations from another module, it must __import__ that module.
+For a file to use declarations from another module, it must __import__ said module.
 The __import__ keyword has a file scope. Therefore, if `file1.c2` imports module `stdio`,
 `file2.c2` still cannot use `stdio`'s symbols, unless it imports `stdio` as well.
 
@@ -60,9 +60,9 @@ import net;
 So `file1.c2` can use external symbols from `file` and `storage`, while `file2.c2`
 can only use symbols from `file` and `net`.
 
-One big advantage of not using c-style header-file includes is that no filenames will
-ever appear in the code. So renaming/moving the files for some modules requires NO
-change in other code whatsoever, even if it uses that module!! Powerful stuff.
+One big advantage of not using C-style header-file includes is that no filenames will
+ever appear in the code. This means renaming/moving the files of modules requires
+**NO** change to other code whatsoever, even if said code uses the module itself!! Powerful stuff.
 
 ## symbol visibility
 
@@ -78,8 +78,8 @@ public func void init() { .. }
 func void open() { .. }
 ```
 
-So other modules can use the `init()` function after importing foo, but only files in the
-`foo` module can use `open()`.
+In this example, the other modules can use the `init()` function after importing foo, but
+only files in the `foo` module can use `open()`.
 
 ## symbol resolving
 To access symbols of other modules, the module prefix is added, followed by a dot:
@@ -97,25 +97,25 @@ func void test() {
 }
 ```
 A global symbol is only allowed ONCE per module, whether __public__ or not. This makes
-`module.symbol` unique. In the example above, both modules `one` and `two` have the
-`test` symbol.
+`module.symbol` unique. In the example above, all three modules have the
+`test` symbol, but no clash occurs, since it is always apparent from which module which symbol comes.
 
 ### import as
-When importing a module with a long name, C2 allows aliasing the module name (applies for the
-current file only!), like:
+When importing a module with a long name, C2 allows aliasing the module name (applied to the
+current file only!), like this:
 
 ```c
 module foo;
 
 import extended_filesystems_io as fs;
 ```
-external symbols can now use the shorter `fs` prefix. Even now, using the full name is allowed!
+external symbols can now use the shorter `fs` prefix. Even after aliasing, using the full name is still allowed!
 
 ### import local
 When using a lot of external symbols, the constant prefixing can be cumbersome. C2
 allows using the external symbols of a module directly (without any prefix) when the
 import statement is followed by the keyword __local__. This can also be combined with
-the __as__ keyword, making the prefix optional.
+aliasing (the __as__ keyword), making the prefix completely optional.
 ```c
 import networking as net local;
 import filesystem local;
@@ -123,11 +123,11 @@ import filesystem local;
 Symbols of both `networking` and `filesystem` can be used without prefix. If a symbol
 can be resolved unambiguously (for the current module and set of imports), the module
 prefix is optional. So if both `networking` and `filesystem` have a function called `open()`,
-it will still have to be prefixed, since C2 allows no ambiguous symbol use.
+it will still have to be prefixed, since C2 does not allow usage of ambiguous symbols.
 
-The result of __modules__ and the __import .. (as ..) (local)__, is that there is no
+The result of __modules__ and the __import .. (as ..) (local)__ is that there is no
 need to constantly prefix the __definition__ part of the code anymore. In C it is common
-for a library to prefix all symbols, to avoid name-clashes, for example:
+for a library to prefix all symbols to avoid name clashes, for example:
 
 `networking.h`
 ```c

--- a/documentation/docs/language/naming.md
+++ b/documentation/docs/language/naming.md
@@ -1,10 +1,10 @@
 
 ## naming
 
-Unlike many other languages, C2 enforces the way way elements of the language
+Unlike many other languages, C2 enforces the way the elements of the language
 are named. This is done to unify coding styles and make it easier to read the
-code. Currently only the first character of a name is enforced as either Upper
-cased or lower cased, depending on the type of element.
+code. Currently only the first character of a name is enforced as either Upper-cased
+or lower-cased, depending on the type of element.
 
 Elements that must start with a *lower* cased character:
 

--- a/documentation/docs/language/struct_functions.md
+++ b/documentation/docs/language/struct_functions.md
@@ -1,7 +1,7 @@
 
-Another new feature in C2 is __struct-functions__.
+Another new feature in C2 are the __struct-functions__.
 
-Struct-functions is a _syntatic-sugar_ feature that makes code more readable.
+The struct-functions are a _syntatic-sugar_ feature that makes code more readable.
 
 The example below shows how it works:
 
@@ -31,14 +31,14 @@ func void example() {
 ## rules
 * struct-functions only work on struct/union types
 * struct-functions are defined in the same module as the struct (not necessary the same file!)
-* for a type type named _Foo_, struct functions must start with _foo\__. So the initial character changes to lower case and the name
-    is followed by an underscore.
+* for a type type named _Foo_, struct functions must start with _foo\__ prefix. The initial character is
+    changed to lower case and the name is followed by an underscore
 * there cannot be a regular member _x_ and a struct function _foo\_x_.
-* a static struct-functions is called on the type itself: Foo.myfunc(); It's not allowed
-    to call this on a variable.
+* a static struct-function is called on the type itself: Foo.myfunc(); It's not allowed
+    to call this on a variable
 * a static struct-function has no argument requirements
-* a (non-static) struct-functions is required to have 'Type\*' or 'const Type\*' as first argument
-* it's not allowed to use a struct-function for other uses then for a call. So 'Ptr p = var.init'
+* a (non-static) struct-function is required to have 'Type\*' or 'const Type\*' as the first argument
+* it's not allowed to use a struct-function for other uses than to be called. So 'Ptr p = var.init'
     will result in an error
 * sub-structs cannot have struct functions
 
@@ -79,8 +79,8 @@ for more examples, see the tests in _c2compiler/test/Functions/struct_functions/
 
 ###bigger example
 
-Or another example, also using opaque pointers:
-Module inner offers an API:
+Or another example, which also uses the opaque pointers:
+Module __inner__ offers an API:
 
 ```c
 module inner;
@@ -116,7 +116,7 @@ public func void shape_free(Shape* shape) {
 }
 ```
 
-is used by outer:
+which is used by module outer:
 
 ```c
 module outer;
@@ -130,7 +130,7 @@ func void example() {
 }
 ```
 
-_NOTE_: outer is not allowed access Shape's regular members directly.
+_NOTE_: outer is not allowed to access Shape's regular members directly.
 
 Since struct-functions are _syntactic-sugar_, the same example can also be done
 without them:
@@ -142,8 +142,8 @@ import inner local;
 
 func void example() {
     Shape* s = shape_create(3);
-    shape_print(&s);
-    shape_free(&s);
+    shape_print(s);
+    shape_free(s);
 }
 ```
 

--- a/documentation/docs/language/user_types.md
+++ b/documentation/docs/language/user_types.md
@@ -1,8 +1,8 @@
 
 The syntax to define new types is very standard and uniform: `type <name> <definition>`
 Like all global declarations, they may also have the __public__ specifier in front.
-Note that the __public__ specifier is required when the type is used as a parameter or return type
-of a public symbol
+Note that the __public__ specifier is required when the type is used as a parameter, return type
+or a member of a public symbol.
 
 The definition can be:
 
@@ -29,7 +29,7 @@ following:
 ```c
 public type Callback func void(int32 a, bool b);
 ```
-This defines a function pointer type to functions that return nothing and need 2
+This defines a function pointer type to functions that return nothing and require two
 arguments.
 
 ## struct/union types

--- a/documentation/docs/language/variables.md
+++ b/documentation/docs/language/variables.md
@@ -1,5 +1,5 @@
 
-variables in C2 look a lot like variables in C (on purpose), so:
+Variables in C2 look a lot like variables in C (on purpose), so:
 
 ```c
 int32 counter = 0;
@@ -7,15 +7,15 @@ public bool hasBool = false;
 Point* p = nil;
 ```
 
-the __public__ keyword can only be used for `global` variables. The __local__ keyword
+The __public__ keyword can only be used for `global` variables. The __local__ keyword
 only on `non-global` ones. Easy.
 
 ### local keyword
 
 The __local__ keyword has the same meaning as the __static__ keyword when used on local
-(as in non-global)
-variables in C; their lifetime is bigger then the function. for example calling the function below
-3 times
+(as in non-global) variables in C; their lifetime is bigger then that of the function.
+For example calling the function below 3 times:
+
 ```c
 func void increment() {
     local int32 counter = 0;
@@ -115,7 +115,7 @@ Point[] array = {
 
 ## incremental arrays
 A special feature in C2 are incremental arrays. These can be used to avoid messy macros when
-have some elements of the array depending on some external condition (#ifdef'ed).
+it is required to have some elements of the array present depending on some external condition (__#ifdef__'ed).
 
 To define an incremental array, use the `[+]` array subscript. Entries can then be added from
 different points in the code.


### PR DESCRIPTION
Contains fixed typos, grammar mistakes, rephrased sentences for clarification, solution to obscure type declaration, fixed erroneous code and updated recipe.txt syntax in one of the examples. I have also added some notes and sentences here and there to provide extra info or clarification. Each file has its own commit to allow easy cherry-picking