### PR TITLE
minor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Contents:
 * documentation - mkdocs generated content for c2lang.org/site/
 * website_frontpage - front page for c2lang.org
 
-
+```
 apt install python-pip
 pip install mkdocs
+```

--- a/documentation/docs/development/automated_tests.md
+++ b/documentation/docs/development/automated_tests.md
@@ -1,11 +1,12 @@
 
 The c2c sources include a *test/* directory with automated tests. The tool to run
-these is located in <c2compiler/tools/tester>. These tests are modelled after
-clang's unit test framework and are designed allow creating tests with minimal effort.
+these is located in the repository under
+[tools/tester](https://github.com/c2lang/c2c_native/tree/master/tools/tester).
+These tests are modelled after clang's unit test framework
+and are designed to allow creating tests with minimal effort.
 
-There are several types of test for testing:
+There are several types of tests:
 
 * generated diagnostic notes, warnings and errors
 * generated C code
 * generated IR code
-

--- a/documentation/docs/language/attributes.md
+++ b/documentation/docs/language/attributes.md
@@ -92,7 +92,7 @@ modules can only use that type *by pointer* and are not allowed to dereference i
 
 ```c
 public type Handle struct {
-    ..   // members are not visible outside module
+    ..   // members are not visible outside of the module
 } @(opaque)
 ```
 


### PR DESCRIPTION
added missing words
added missing code block quotes to setup commands of README
edit (another commit):
development/automated_tests.md: had a broken link which was then invisible and generally made mkdocs generate a HTML-mess
development/automated_tests.md: added missing word, removed redundant one and fixed typo with that